### PR TITLE
fix creature collection size bug

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1841,7 +1841,7 @@ function inventoryCollection(collectionType) { // returns a string with the curr
     const currentCollectionMax = collectionMaxes[collectionType];
     return currentCollectionCount + '/' + currentCollectionMax;
   } else { // catch case that collection data is not created yet
-    return '0/80';
+    return `0/${collectionMaxes[collectionType]}`;
   }
 }
 


### PR DESCRIPTION
…ays return 0/80 when no collection is present -- instead it returns the max size for the collection taken as an argument
![creature-collection-size-bug](https://user-images.githubusercontent.com/105157437/200356123-9a5c0e0e-5cc8-4722-91e6-161553ea9fc6.png)
